### PR TITLE
Add ability to redirect Python warnings

### DIFF
--- a/+light_python_wrapper/light_python_wrapper.m
+++ b/+light_python_wrapper/light_python_wrapper.m
@@ -30,6 +30,12 @@ classdef light_python_wrapper < dynamicprops
                 out = parse_without_signature(args);
             end
         end
+        function out = redirect_python_warnings()
+            curdir = fileparts(mfilename('fullpath'));
+            insert(py.sys.path, int32(0), curdir);
+            py.importlib.import_module('redirect_python_warnings');
+            remove(py.sys.path, curdir);
+        end
     end
     methods
         function [out, docTopic] = help(obj)

--- a/+light_python_wrapper/redirect_python_warnings.py
+++ b/+light_python_wrapper/redirect_python_warnings.py
@@ -1,0 +1,7 @@
+import warnings, sys
+
+# Redirect Python warnings to stdout so they can be seen from Matlab
+def customwarn(message, category, filename, lineno, file=None, line=None):
+    sys.stdout.write(warnings.formatwarning(message, category, filename, lineno))
+
+warnings.showwarning = customwarn


### PR DESCRIPTION
I wasn't sure where exactly to put the redirect, so I've put it in its own static method so it would have to be called explicitly by any of its subclasses, for example in this branch https://github.com/pace-neutrons/horace-euphonic-interface/commit/817c45f41403754bb87343f40b3d1ef6bfa809bc, that's probably the least intrusive way for now.

Unless there's a better way to do it? I'm not that familiar with Matlab classes