### PR TITLE
Replace verLessThan in p2m

### DIFF
--- a/+light_python_wrapper/m2p.m
+++ b/+light_python_wrapper/m2p.m
@@ -46,8 +46,11 @@ else
             p = m;
     end
     if ~isscalar(m) && ~ischar(m)
-        vers = version();
-        is_old_version = sscanf(vers(1:3), '%f') < 9.5
+        persistent is_old_version;
+        if isempty(is_old_version)
+            vers = version();
+            is_old_version = sscanf(vers(1:3), '%f') < 9.5;
+        end
         if is_old_version
             p = py.numpy.array(transpose(p(:)));
             if neversqueeze || any( size(m)~=1 & size(m)~=numel(m) )

--- a/+light_python_wrapper/m2p.m
+++ b/+light_python_wrapper/m2p.m
@@ -46,7 +46,9 @@ else
             p = m;
     end
     if ~isscalar(m) && ~ischar(m)
-        if verLessThan('matlab','9.5')
+        vers = version();
+        is_old_version = sscanf(vers(1:3), '%f') < 9.5
+        if is_old_version
             p = py.numpy.array(transpose(p(:)));
             if neversqueeze || any( size(m)~=1 & size(m)~=numel(m) )
                 p=p.reshape( int64(size(m)) );

--- a/+light_python_wrapper/p2m.m
+++ b/+light_python_wrapper/p2m.m
@@ -15,26 +15,7 @@
 % along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 function m = p2m(p)
-    if isa(p,'py.complex') % a scalar
-        m = py.numpy.array(p).tolist(); % MATLAB converts the one element list to a complex number automatically
-    elseif contains(class(p),'uint','IgnoreCase',true)
-        m = uint64(p);
-    elseif contains(class(p),'int','IgnoreCase',true)
-        m = int64(p);
-    elseif isa(p, 'light_python_wrapper.light_python_wrapper')
-        m = light_python_wrapper.p2m(p.pyobj);
-    elseif isa(p, 'py.tuple') || isa(p, 'py.list')
-        m = cell(p);
-        for ii = 1:numel(m)
-            m{ii} = light_python_wrapper.p2m(m{ii});
-        end
-    elseif isa(p, 'py.set')
-        m = light_python_wrapper.p2m(py.list(p));
-    elseif isnumeric(p)
-        m = p;
-    elseif isa(p, 'py.str')
-        m = char(p);
-    elseif py.hasattr(p, 'dtype')
+    if py.hasattr(p, 'dtype')
         vers = version();
         is_old_version = sscanf(vers(1:3), '%f') < 9.4; % before 2018a(?) For sure by 2018b=9.5
         if is_old_version
@@ -60,7 +41,9 @@ function m = p2m(p)
             end
         else
             eltype = lower(string(p.dtype.name));
-            if contains(eltype,'complex')
+            if contains(eltype,'float')
+                m = double(p);
+            elseif contains(eltype,'complex')
                 rp = py.numpy.array(p.real);
                 ip = py.numpy.array(p.imag);
                 eltype = lower(string(rp.dtype.name));
@@ -100,6 +83,25 @@ function m = p2m(p)
                 m = double(p);
             end
         end
+    elseif isa(p,'py.complex') % a scalar
+        m = py.numpy.array(p).tolist(); % MATLAB converts the one element list to a complex number automatically
+    elseif contains(class(p),'uint','IgnoreCase',true)
+        m = uint64(p);
+    elseif contains(class(p),'int','IgnoreCase',true)
+        m = int64(p);
+    elseif isa(p, 'light_python_wrapper.light_python_wrapper')
+        m = light_python_wrapper.p2m(p.pyobj);
+    elseif isa(p, 'py.tuple') || isa(p, 'py.list')
+        m = cell(p);
+        for ii = 1:numel(m)
+            m{ii} = light_python_wrapper.p2m(m{ii});
+        end
+    elseif isa(p, 'py.set')
+        m = light_python_wrapper.p2m(py.list(p));
+    elseif isnumeric(p)
+        m = p;
+    elseif isa(p, 'py.str')
+        m = char(p);
     else
         m = light_python_wrapper.generic_python_wrapper(p);
     end

--- a/+light_python_wrapper/p2m.m
+++ b/+light_python_wrapper/p2m.m
@@ -35,7 +35,9 @@ function m = p2m(p)
     elseif isa(p, 'py.str')
         m = char(p);
     elseif py.hasattr(p, 'dtype')
-        if verLessThan('matlab','9.4') % before 2018a(?) For sure by 2018b=9.5
+        vers = version();
+        is_old_version = sscanf(vers(1:3), '%f') < 9.4; % before 2018a(?) For sure by 2018b=9.5
+        if is_old_version
             warning('light_python_wrapper:p2m','Fast conversion of numpy.ndarrays not supported by this version of MATLAB. Consider upgrading.');
             ndim = int64(p.ndim);
             nmel = int64(p.size);

--- a/+light_python_wrapper/p2m.m
+++ b/+light_python_wrapper/p2m.m
@@ -15,9 +15,13 @@
 % along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 function m = p2m(p)
-    if py.hasattr(p, 'dtype')
-        vers = version();
-        is_old_version = sscanf(vers(1:3), '%f') < 9.4; % before 2018a(?) For sure by 2018b=9.5
+    ptype = lower(class(p));
+    if strcmp(ptype,'py.numpy.ndarray')
+        persistent is_old_version;
+        if isempty(is_old_version)
+            vers = version();
+            is_old_version = sscanf(vers(1:3),'%f') < 9.4; % before 2018a(?) For sure by 2018b=9.5
+        end
         if is_old_version
             warning('light_python_wrapper:p2m','Fast conversion of numpy.ndarrays not supported by this version of MATLAB. Consider upgrading.');
             ndim = int64(p.ndim);
@@ -83,24 +87,24 @@ function m = p2m(p)
                 m = double(p);
             end
         end
-    elseif isa(p,'py.complex') % a scalar
+    elseif strcmp(ptype,'py.complex') % a scalar
         m = py.numpy.array(p).tolist(); % MATLAB converts the one element list to a complex number automatically
-    elseif contains(class(p),'uint','IgnoreCase',true)
+    elseif contains(ptype,'uint')
         m = uint64(p);
-    elseif contains(class(p),'int','IgnoreCase',true)
+    elseif contains(ptype,'int')
         m = int64(p);
-    elseif isa(p, 'light_python_wrapper.light_python_wrapper')
+    elseif strcmp(ptype,'light_python_wrapper.light_python_wrapper')
         m = light_python_wrapper.p2m(p.pyobj);
-    elseif isa(p, 'py.tuple') || isa(p, 'py.list')
+    elseif strcmp(ptype,'py.tuple') || strcmp(ptype,'py.list')
         m = cell(p);
         for ii = 1:numel(m)
             m{ii} = light_python_wrapper.p2m(m{ii});
         end
-    elseif isa(p, 'py.set')
+    elseif strcmp(ptype,'py.set')
         m = light_python_wrapper.p2m(py.list(p));
     elseif isnumeric(p)
         m = p;
-    elseif isa(p, 'py.str')
+    elseif strcmp(ptype,'py.str')
         m = char(p);
     else
         m = light_python_wrapper.generic_python_wrapper(p);


### PR DESCRIPTION
While profiling Euphonic vs. Brille on IDAaaS I found that p2m was quite slow, and to my surprise I found it was due to the `verLessThan` call. I found that `ver('MATLAB')` was also slow (maybe it's getting the license information?) so had to go with `version()` and do some nasty string parsing, but I think what `version()` returns should be consistent?

It was also spending quite a lot of time in `elseif` statements, so I put the most common case, a Numpy array of floats, as the first case and that's saved a bit of time too.

There don't seem to be any performance issues in p2m when running on my laptop, but since IDAaaS is one of the most common systems we should probably make sure it isn't unnecessarily slow...

Profiling attached (sorry had to append .txt to the filetypes so they would upload):
[Original p2m profiling](https://github.com/pace-neutrons/light_python_wrapper/files/8225891/p2m_prof_verlessthan.html.txt)
[p2m profiling using version()](https://github.com/pace-neutrons/light_python_wrapper/files/8225890/p2m_prof_versionfunc_reorderif.html.txt)
[p2m profiling using version() with rearranged if statements](https://github.com/pace-neutrons/light_python_wrapper/files/8225892/p2m_prof_versionfunc.html.txt)