### PR TITLE
Revert 89dd660 - use verLessThan again

### DIFF
--- a/+light_python_wrapper/m2p.m
+++ b/+light_python_wrapper/m2p.m
@@ -15,6 +15,7 @@
 % along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 function p = m2p(m,dtype,neversqueeze)
+persistent is_old_version;
 if nargin<3 || isempty(neversqueeze) || ~islogical(neversqueeze)
     neversqueeze = false;
 end
@@ -46,10 +47,8 @@ else
             p = m;
     end
     if ~isscalar(m) && ~ischar(m)
-        persistent is_old_version;
         if isempty(is_old_version)
-            vers = version();
-            is_old_version = sscanf(vers(1:3), '%f') < 9.5;
+            is_old_version = verLessThan('matlab', '9.5');
         end
         if is_old_version
             p = py.numpy.array(transpose(p(:)));

--- a/+light_python_wrapper/p2m.m
+++ b/+light_python_wrapper/p2m.m
@@ -15,12 +15,11 @@
 % along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 function m = p2m(p)
+    persistent is_old_version;
     ptype = lower(class(p));
     if strcmp(ptype,'py.numpy.ndarray')
-        persistent is_old_version;
         if isempty(is_old_version)
-            vers = version();
-            is_old_version = sscanf(vers(1:3),'%f') < 9.4; % before 2018a(?) For sure by 2018b=9.5
+            is_old_version = verLessThan('matlab', '9.4'); % before 2018a(?) For sure by 2018b=9.5
         end
         if is_old_version
             warning('light_python_wrapper:p2m','Fast conversion of numpy.ndarrays not supported by this version of MATLAB. Consider upgrading.');


### PR DESCRIPTION
Oops, turned out my last change is causing the Numpy warning to be triggered on 2022a (9.12)...